### PR TITLE
Added default columns to gallery block

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -147,6 +147,10 @@ class Block implements ArrayAccess {
 			];
 		}
 
+		if ( 'core/gallery' === $data['blockName'] && ! isset( $attributes['columns'] ) ) {
+			$attributes['columns'] = min( count( $data['innerBlocks'] ), 3 );
+		}
+
 		$types = [ $block_type['attributes'] ];
 
 		foreach ( $block_type['deprecated'] ?? [] as $deprecated ) {


### PR DESCRIPTION
Fix #49 
For the core/gallery block, default columns value is determined by JS and it's not available in json data.

`js/dist/block-library.js line 16737`
```
function defaultColumnsNumber(imageCount) {
	return imageCount ? Math.min(3, imageCount) : 3;
}
```
