### PR TITLE
Fix-60 : Fixed issue with Core fields query

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -57,6 +57,16 @@ class Block implements ArrayAccess {
 			$source = $value['source'] ?? null;
 
 			switch ( $source ) {
+				case 'rich-text':
+					// Most 'html' sources were converted to 'rich-text' in WordPress 6.5.
+					// https://github.com/WordPress/gutenberg/pull/43204
+					$source_node = ! empty( $value['selector'] ) ? $node->findOne( $value['selector'] ) : $node;
+
+					if ( $source_node ) {
+						$result[ $key ] = $source_node->innerhtml;
+					}
+
+					break;
 				case 'html':
 					$source_node = ! empty( $value['selector'] ) ? $node->findOne( $value['selector'] ) : $node;
 

--- a/src/Schema/Types/BlockTypes.php
+++ b/src/Schema/Types/BlockTypes.php
@@ -263,6 +263,10 @@ class BlockTypes {
 
 			$registry = Registry::get_registry();
 
+			if ( empty( $registry ) || ! is_array( $registry ) ) {
+				return;
+			}
+
 			foreach ( $registry as $block_name => $block_type ) {
 				$type_names[] = self::register_block_type( $block_type, $type_registry );
 			}

--- a/src/Schema/Types/BlockTypes.php
+++ b/src/Schema/Types/BlockTypes.php
@@ -46,6 +46,7 @@ class BlockTypes {
 
 		if ( isset( $attribute['type'] ) ) {
 			switch ( $attribute['type'] ) {
+				case 'rich-text':
 				case 'string':
 					$type = 'String';
 					break;
@@ -123,6 +124,7 @@ class BlockTypes {
 
 	protected static function normalize_attribute_value( $value, $type ) {
 		switch ( $type ) {
+			case 'rich-text':
 			case 'string':
 				return (string) $value;
 			case 'number':


### PR DESCRIPTION
Fixed issue #60 
With the WP core upgrade they added `rich-text` field type and updated from `string` to `rich-text` for some core fields.
Added handling for `rich-text` type.