### PR TITLE
Fix-62: Making rich-text non nullable type by default

### DIFF
--- a/src/Schema/Types/BlockTypes.php
+++ b/src/Schema/Types/BlockTypes.php
@@ -47,6 +47,8 @@ class BlockTypes {
 		if ( isset( $attribute['type'] ) ) {
 			switch ( $attribute['type'] ) {
 				case 'rich-text':
+					$type = [ 'non_null' => 'String' ];
+					break;
 				case 'string':
 					$type = 'String';
 					break;
@@ -82,7 +84,7 @@ class BlockTypes {
 			$type = 'String';
 		}
 
-		if ( null !== $type ) {
+		if ( null !== $type && !is_array( $type )) {
 			$default_value = $attribute['default'] ?? null;
 
 			if ( isset( $default_value ) ) {


### PR DESCRIPTION
 Making rich-text non nullable type by default